### PR TITLE
Add GitHub copilot changes to accept data.frame instead of list

### DIFF
--- a/R/daisyTimeline.R
+++ b/R/daisyTimeline.R
@@ -2,14 +2,44 @@
 #'
 #' Create a Daisy Timeline
 #'
+#' @param events A data frame with columns 'date' and 'content', and optionally 'side'
+#' @param width Width of the widget
+#' @param height Height of the widget
+#' @param elementId HTML element ID
+#'
 #' @import htmlwidgets
 #'
 #' @export
 daisyTimeline <- function(events, width = NULL, height = NULL, elementId = NULL) {
-  # events is a list of lists: each item has date, content, maybe side
+  # Convert data frame to list of lists for JavaScript consumption
+  if (is.data.frame(events)) {
+    # Check required columns
+    if (!all(c("date", "content") %in% names(events))) {
+      stop("Data frame must contain 'date' and 'content' columns")
+    }
+    
+    # Convert data frame to list of lists
+    events_list <- lapply(seq_len(nrow(events)), function(i) {
+      event <- list(
+        date = as.character(events$date[i]),
+        content = as.character(events$content[i])
+      )
+      
+      # Add side column if it exists
+      if ("side" %in% names(events)) {
+        event$side <- as.character(events$side[i])
+      }
+      
+      return(event)
+    })
+  } else {
+    # Backward compatibility: if events is already a list, use it as is
+    events_list <- events
+  }
+  
   htmlwidgets::createWidget(
     name = "daisyTimeline",
-    x = list(events = events),
+    x = list(events = events_list),
     width = width,
     height = height,
     package = "daisyuiwidget1",

--- a/inst/testcode.R
+++ b/inst/testcode.R
@@ -10,12 +10,22 @@ ui <- fluidPage(
 
 server <- function(input, output) {
   output$timeline <- renderDaisyTimeline({
-    daisyTimeline(list(
-      list(date = "2022", content = "Planning phase"),
-      list(date = "2023", content = "Development started"),
-      list(date = "2024", content = "Launch 🚀"),
-      list(date = "2025", content = "IPO 🚀")
-    ))
+    # Using data frame format (recommended)
+    events_df <- data.frame(
+      date = c("2022", "2023", "2024", "2025"),
+      content = c("Planning phase", "Development started", "Launch 🚀", "IPO 🚀"),
+      stringsAsFactors = FALSE
+    )
+    
+    daisyTimeline(events_df)
+    
+    # Alternative: still works with list format for backward compatibility
+    # daisyTimeline(list(
+    #   list(date = "2022", content = "Planning phase"),
+    #   list(date = "2023", content = "Development started"),
+    #   list(date = "2024", content = "Launch 🚀"),
+    #   list(date = "2025", content = "IPO 🚀")
+    # ))
   })
 }
 

--- a/vignettes/daisyChains.Rmd
+++ b/vignettes/daisyChains.Rmd
@@ -127,6 +127,21 @@ Here's a minified responsive timeline taken from https://daisyui.com/components/
 ```{r setup}
 library(daisyuiwidget1)
 
+# Using data frame format (recommended)
+events_df <- data.frame(
+  date = c("2022", "2023", "2024", "2025"),
+  content = c("Planning phase", "Development started", "Launch 🚀", "IPO 🚀"),
+  stringsAsFactors = FALSE
+)
+
+daisyTimeline(events_df)
+```
+
+## Alternative: List format (backward compatibility)
+
+The function still accepts the original list format for backward compatibility:
+
+```{r list_format}
 daisyTimeline(list(
       list(date = "2022", content = "Planning phase"),
       list(date = "2023", content = "Development started"),


### PR DESCRIPTION
Closes #3

Initial PR made with Copilot code without modification.

GitHub Copilot summary is below

-----------------------------------------------------------

Perfect! I've successfully modified the daisyUI HTML widget code to accept a data frame instead of a list of lists. Here's a summary of the changes made:

Changes Made:
Modified daisyTimeline() function in daisyTimeline.R:

Added proper parameter documentation for the events parameter
Added logic to check if events is a data frame
If it's a data frame, validates that required columns (date and content) exist
Converts the data frame to the list format that the JavaScript expects
Maintains backward compatibility by still accepting the original list format
Handles optional side column if present in the data frame
Updated test code in testcode.R:

Changed the example to use a data frame instead of a list
Added commented example showing the old list format still works
Updated vignette in daisyChains.Rmd:

Added example showing data frame usage
Added section showing backward compatibility with list format
Key Features:
Data Frame Support: The function now accepts data frames with date and content columns (and optionally side)
Backward Compatibility: Still works with the original list of lists format
Input Validation: Checks for required columns when using data frame format
Type Conversion: Safely converts data frame columns to character strings for JavaScript consumption
Usage Examples:

# New data frame format (recommended)events_df <- data.frame(  date = c("2022", "2023", "2024", "2025"),  content = c("Planning phase", "Development started", "Launch 🚀", "IPO 🚀"))daisyTimeline(events_df)# Old list format (still works)daisyTimeline(list(  list(date = "2022", content = "Planning phase"),  list(date = "2023", content = "Development started"),  list(date = "2024", content = "Launch 🚀"),  list(date = "2025", content = "IPO 🚀")))
The JavaScript code remains unchanged since it still receives the same data structure (list of objects with date/content properties), but now users have a more convenient R-like interface using data frames.